### PR TITLE
Fix for lwIP Arduino on Linux

### DIFF
--- a/RF24Client.cpp
+++ b/RF24Client.cpp
@@ -30,8 +30,8 @@ uip_userdata_t RF24Client::all_data[UIP_CONNS];
         #include "lwip/tcpip.h"
         #include "lwip/timeouts.h"
     #else
-        #include "lwip\include\lwip\tcp.h"
-        #include "lwip\include\lwip\tcpip.h"
+        #include "lwip/include/lwip/tcp.h"
+        #include "lwip/include/lwip/tcpip.h"
     #endif
 
     #include "RF24Ethernet.h"

--- a/RF24Udp.cpp
+++ b/RF24Udp.cpp
@@ -33,8 +33,8 @@ int32_t RF24UDP::dataOutPos;
             #include "lwip/udp.h"
             #include "lwip/tcpip.h"
         #else
-            #include "lwip\include\lwip\udp.h"
-            #include "lwip\include\lwip\tcpip.h"
+            #include "lwip/include/lwip/udp.h"
+            #include "lwip/include/lwip/tcpip.h"
         #endif
     #endif
 


### PR DESCRIPTION
- Using wrong slashes for lwIP Arduino library includes, fails compilation on Linux