### PR TITLE
Multiple conn fixes

### DIFF
--- a/RF24Client.cpp
+++ b/RF24Client.cpp
@@ -320,7 +320,6 @@ err_t RF24Client::serverTimeouts(void* arg, struct tcp_pcb* tpcb)
         if (state->backlogWasClosed == true) {
             if (millis() - state->closeTimer > 5000) {
                 tcp_abort(tpcb);
-                myPcb = nullptr;
                 return ERR_ABRT;
             }
         }
@@ -447,7 +446,7 @@ err_t RF24Client::accept(void* arg, struct tcp_pcb* tpcb, err_t err)
     }
     bool actState = activeState;
 
-    if (myPcb != nullptr || gState[activeState]->connected == true) {
+    if (myPcb != nullptr) {
 
         IF_RF24ETHERNET_DEBUG_CLIENT(Serial.print("Server: Accept w/already connected: Accepted_Conns - Delayed_Conns == "); Serial.println(accepts););
         tcp_backlog_delayed(tpcb);
@@ -459,6 +458,8 @@ err_t RF24Client::accept(void* arg, struct tcp_pcb* tpcb, err_t err)
     else {
         myPcb = tpcb;
         tcp_poll(tpcb, serverTimeouts, 8);
+        activeState = !activeState;
+        actState = activeState;
         gState[actState]->connected = true;
     }
 
@@ -831,7 +832,6 @@ void RF24Client::stop()
             }
     #endif
         }
-        myPcb = nullptr;
     }
 
     gState[activeState]->connected = false;
@@ -932,10 +932,6 @@ test2:
     }
 
     bool initialActiveState = activeState;
-
-    if (gState[initialActiveState] == nullptr) {
-        return ERR_CLSD;
-    }
 
     char buffer[size];
     uint32_t position = 0;


### PR DESCRIPTION
This should fix and closes #59 once my final testing is complete.

Submitting as draft pending further testing, but initial tests == no data errors & server only accepting 2 connections.

After a quick and dirty test, AcceptedConns - DelayedConns == -1, so there may still be a minor issue going on. This should pretty much stay at 0 AFAIK, but this is much better than it was previously. ie: For every 1 accepted back-logged connection, there should only be 1 delayed accepted connection.