### PR TITLE
Fix RF24Client lwIP buffer and PCB teardown issues

### DIFF
--- a/RF24Client.cpp
+++ b/RF24Client.cpp
@@ -972,7 +972,7 @@ test2:
         return u->out_pos;
     }
     u->hold = false;
-    return -1;
+    return 0;
 #else
 
     bool initialActiveState = activeState;
@@ -981,7 +981,7 @@ test2:
 
     while (size > chunk) {
         if (myPcb == nullptr)
-            return ERR_CLSD;
+            return 0;
         gState[initialActiveState]->waiting_for_ack = true;
         err_t write_err = blocking_write(myPcb, gState[initialActiveState], reinterpret_cast<const char*>(&buf[position]), chunk);
         if (write_err != ERR_OK) {
@@ -996,7 +996,7 @@ test2:
     }
 
     if (myPcb == nullptr)
-        return ERR_CLSD;
+        return 0;
     gState[initialActiveState]->waiting_for_ack = true;
     err_t write_err = blocking_write(myPcb, gState[initialActiveState], reinterpret_cast<const char*>(&buf[position]), size);
 
@@ -1004,7 +1004,7 @@ test2:
         gState[initialActiveState]->result = write_err;
         gState[initialActiveState]->connected = false;
         _stop();
-        return (write_err);
+        return 0;
     }
 
     return position + size;

--- a/RF24Client.cpp
+++ b/RF24Client.cpp
@@ -860,12 +860,12 @@ void RF24Client::_stop()
     myPcb = nullptr;
 
     if (pcb != nullptr) {
-        if (pcb->state != CLOSED) {
     #if defined RF24ETHERNET_CORE_REQUIRES_LOCKING
-            if (Ethernet.useCoreLocking) {
-                ETHERNET_APPLY_LOCK();
-            }
+        if (Ethernet.useCoreLocking) {
+            ETHERNET_APPLY_LOCK();
+        }
     #endif
+        if (pcb->state != CLOSED) {
             tcp_arg(pcb, NULL);
             tcp_recv(pcb, NULL);
             tcp_sent(pcb, NULL);
@@ -875,12 +875,12 @@ void RF24Client::_stop()
             if (err != ERR_OK) {
                 tcp_abort(pcb);
             }
-    #if defined RF24ETHERNET_CORE_REQUIRES_LOCKING
-            if (Ethernet.useCoreLocking) {
-                ETHERNET_REMOVE_LOCK();
-            }
-    #endif
         }
+    #if defined RF24ETHERNET_CORE_REQUIRES_LOCKING
+        if (Ethernet.useCoreLocking) {
+            ETHERNET_REMOVE_LOCK();
+        }
+    #endif
     }
 
     gState[activeState]->connected = false;

--- a/RF24Client.cpp
+++ b/RF24Client.cpp
@@ -988,7 +988,7 @@ test2:
             gState[initialActiveState]->result = write_err;
             gState[initialActiveState]->connected = false;
             _stop();
-            return write_err;
+            return 0;
         }
         position += chunk;
         size -= chunk;

--- a/RF24Client.cpp
+++ b/RF24Client.cpp
@@ -976,7 +976,7 @@ test2:
 #else
 
     bool initialActiveState = activeState;
-    size_t chunk = MAX_PAYLOAD_SIZE - 14;
+    size_t chunk = MAX_PAYLOAD_SIZE - 14; // 14 = Ethernet/link-layer header bytes reserved per frame
     size_t position = 0;
 
     while (size > chunk) {

--- a/RF24Client.cpp
+++ b/RF24Client.cpp
@@ -684,27 +684,24 @@ int RF24Client::connect(IPAddress ip, uint16_t port)
             ETHERNET_APPLY_LOCK();
         }
     #endif
-        if (myPcb->state == ESTABLISHED || myPcb->state == SYN_SENT || myPcb->state == SYN_RCVD) {
-            if (tcp_close(myPcb) != ERR_OK) {
-                tcp_abort(myPcb);
-            }
-            //myPcb = NULL;
+
+        tcp_pcb* pcb = myPcb;
+        myPcb = nullptr;
+
+        tcp_arg(pcb, NULL);
+        tcp_recv(pcb, NULL);
+        tcp_sent(pcb, NULL);
+        tcp_err(pcb, NULL);
+
+        tcp_abort(pcb);
+
     #if defined RF24ETHERNET_CORE_REQUIRES_LOCKING
-            if (Ethernet.useCoreLocking) {
-                ETHERNET_REMOVE_LOCK();
-            }
-    #endif
-            Ethernet.update();
-            return ERR_CLSD;
+        if (Ethernet.useCoreLocking) {
+            ETHERNET_REMOVE_LOCK();
         }
-        else {
-    #if defined RF24ETHERNET_CORE_REQUIRES_LOCKING
-            if (Ethernet.useCoreLocking) {
-                ETHERNET_REMOVE_LOCK();
-            }
     #endif
-            myPcb = NULL;
-        }
+
+        return ERR_CLSD;
     }
 
     #if defined RF24ETHERNET_CORE_REQUIRES_LOCKING
@@ -718,7 +715,6 @@ int RF24Client::connect(IPAddress ip, uint16_t port)
     }
 
     if (!myPcb) {
-
     #if defined RF24ETHERNET_CORE_REQUIRES_LOCKING
         if (Ethernet.useCoreLocking) {
             ETHERNET_REMOVE_LOCK();
@@ -728,7 +724,7 @@ int RF24Client::connect(IPAddress ip, uint16_t port)
     }
 
     dataSize[activeState] = 0;
-    memset(incomingData[activeState], 0, sizeof(incomingData[activeState]));
+    memset(incomingData[activeState], 0, INCOMING_DATA_SIZE);
 
     gState[activeState]->finished = false;
     gState[activeState]->connected = false;
@@ -881,20 +877,25 @@ void RF24Client::stop()
 #if USE_LWIP > 0
 void RF24Client::_stop()
 {
-    if (myPcb != nullptr) {
+    tcp_pcb* pcb = myPcb;
+    myPcb = nullptr;
 
-        if (myPcb->state != CLOSED) {
-
+    if (pcb != nullptr) {
+        if (pcb->state != CLOSED) {
     #if defined RF24ETHERNET_CORE_REQUIRES_LOCKING
             if (Ethernet.useCoreLocking) {
                 ETHERNET_APPLY_LOCK();
             }
     #endif
-            err_t err = tcp_close(myPcb);
-            if (err != ERR_OK) {
-                tcp_abort(myPcb);
-            }
+            tcp_arg(pcb, NULL);
+            tcp_recv(pcb, NULL);
+            tcp_sent(pcb, NULL);
+            tcp_err(pcb, NULL);
 
+            err_t err = tcp_close(pcb);
+            if (err != ERR_OK) {
+                tcp_abort(pcb);
+            }
     #if defined RF24ETHERNET_CORE_REQUIRES_LOCKING
             if (Ethernet.useCoreLocking) {
                 ETHERNET_REMOVE_LOCK();
@@ -995,44 +996,30 @@ test2:
     return -1;
 #else
 
-    if (myPcb == nullptr) {
-        return ERR_CLSD;
-    }
-
     bool initialActiveState = activeState;
+    size_t chunk = MAX_PAYLOAD_SIZE - 14;
+    size_t position = 0;
 
-    char buffer[size];
-    uint32_t position = 0;
-    uint32_t timeout1 = millis() + 3000;
-
-    while (size > MAX_PAYLOAD_SIZE - 14 && millis() < timeout1) {
-        memcpy(buffer, &buf[position], MAX_PAYLOAD_SIZE - 14);
-
-        if (myPcb == nullptr) {
+    while (size > chunk) {
+        if (myPcb == nullptr)
             return ERR_CLSD;
-        }
         gState[initialActiveState]->waiting_for_ack = true;
-        err_t write_err = blocking_write(myPcb, gState[initialActiveState], buffer, MAX_PAYLOAD_SIZE - 14);
-
+        err_t write_err = blocking_write(myPcb, gState[initialActiveState], reinterpret_cast<const char*>(&buf[position]), chunk);
         if (write_err != ERR_OK) {
             gState[initialActiveState]->result = write_err;
             gState[initialActiveState]->connected = false;
             _stop();
-            return (write_err);
+            return write_err;
         }
-        position += MAX_PAYLOAD_SIZE - 14;
-        size -= MAX_PAYLOAD_SIZE - 14;
+        position += chunk;
+        size -= chunk;
         Ethernet.update();
     }
 
-    memcpy(buffer, &buf[position], size);
-
-    if (myPcb == nullptr) {
+    if (myPcb == nullptr)
         return ERR_CLSD;
-    }
-
     gState[initialActiveState]->waiting_for_ack = true;
-    err_t write_err = blocking_write(myPcb, gState[initialActiveState], buffer, size);
+    err_t write_err = blocking_write(myPcb, gState[initialActiveState], reinterpret_cast<const char*>(&buf[position]), size);
 
     if (write_err != ERR_OK) {
         gState[initialActiveState]->result = write_err;
@@ -1041,7 +1028,7 @@ test2:
         return (write_err);
     }
 
-    return size;
+    return position + size;
 #endif
 }
 

--- a/RF24Client.cpp
+++ b/RF24Client.cpp
@@ -679,28 +679,7 @@ int RF24Client::connect(IPAddress ip, uint16_t port)
 #else
 
     if (myPcb != nullptr) {
-    #if defined RF24ETHERNET_CORE_REQUIRES_LOCKING
-        if (Ethernet.useCoreLocking) {
-            ETHERNET_APPLY_LOCK();
-        }
-    #endif
-
-        tcp_pcb* pcb = myPcb;
-        myPcb = nullptr;
-
-        tcp_arg(pcb, NULL);
-        tcp_recv(pcb, NULL);
-        tcp_sent(pcb, NULL);
-        tcp_err(pcb, NULL);
-
-        tcp_abort(pcb);
-
-    #if defined RF24ETHERNET_CORE_REQUIRES_LOCKING
-        if (Ethernet.useCoreLocking) {
-            ETHERNET_REMOVE_LOCK();
-        }
-    #endif
-
+        _stop();
         return ERR_CLSD;
     }
 


### PR DESCRIPTION
This PR hardens the lwIP path in RF24Client to reduce crashes during connect, write, and teardown flows.

### Changes
- Fixes receive-buffer clearing to wipe the full buffer with INCOMING_DATA_SIZE instead of only clearing a pointer-sized region.
- Removes the stack-allocated variable-length buffer from _write() and sends data directly from the source buffer in bounded chunks.
- Fixes _write() to return the correct total number of bytes written after chunked sends.
- Makes _stop() more defensive by clearing myPcb early, unregistering lwIP callbacks, and then closing/aborting the PCB.
- Cleans up connect() locking/teardown flow to avoid stale PCB reuse and improve lwIP lifecycle handling.

### Why

These changes address a few concrete stability issues in the lwIP client path:

- incorrect receive-buffer initialization
- unnecessary stack pressure during writes on ESP8266
- stale callback / PCB state during connection teardown
- inconsistent connection cleanup behavior

### Expected impact

This should make MQTT/TCP client usage more stable on ESP8266, especially during reconnects, larger writes, and error/close handling.

## Overview

I've been struggling to fix this memory leak. When I fixed the leak, I got exceptions, when I fixed the exceptions, I got a leak. LOL.
I think I have something here worth testing, so putting in a PR.