### PR TITLE
Support Uno R4 w/lwIP

### DIFF
--- a/RF24BoardConfig.h
+++ b/RF24BoardConfig.h
@@ -5,7 +5,7 @@
 /*******************************************************************/
 
 // Initial detection for devices w/CPU >=50MHz
-#if (!defined F_CPU || F_CPU >= 50000000)
+#if (!defined F_CPU || F_CPU >= 45000000)
     // Attempt to use internal stack with non-mbed core for RP2040 or RP2350
     #if (defined ARDUINO_ARCH_RP2040 && !defined ARDUINO_ARCH_MBED) || (defined ARDUINO_ARCH_RP2350 && !defined ARDUINO_ARCH_MBED)
         #ifndef USE_LWIP


### PR DESCRIPTION
Dropped the CPU speed detection for using lwIP to 45MHz since the Uno R4 WiFi can handle using lwIP and gets errors trying to use uIP. It runs at 48MHz. Seems to be the only modification required.

This development is thanks to the folks at Arduino, including Per Tillisch who sent me a free Uno R4 Wifi that I just got today!