### PR TITLE
Fix hangs when using server

### DIFF
--- a/RF24Client.cpp
+++ b/RF24Client.cpp
@@ -350,8 +350,10 @@ err_t RF24Client::serverTimeouts(void* arg, struct tcp_pcb* tpcb)
                 tcp_arg(tpcb, nullptr);
                 tcp_abort(tpcb);
                 tpcb = nullptr;
+                myPcb = nullptr;
                 return ERR_ABRT;
             }
+            myPcb = nullptr;
             return state->result;
 
             // }
@@ -361,6 +363,7 @@ err_t RF24Client::serverTimeouts(void* arg, struct tcp_pcb* tpcb)
                 tcp_arg(tpcb, nullptr);
                 tcp_abort(tpcb);
                 tpcb = nullptr;
+                myPcb = nullptr;
                 return ERR_ABRT;
             }
         }


### PR DESCRIPTION
Need to manually de-allocate main PCB when main server connection is closed else the server can hang up, continually accepting then closing secondary connections but never handling the main PCB.